### PR TITLE
patches/mps_compat: re-enable decode-time cumesh on Apple Silicon (closes the see-through-mesh bug)

### DIFF
--- a/patches/mps_compat.py
+++ b/patches/mps_compat.py
@@ -232,11 +232,24 @@ def patch_birefnet():
 
 
 def patch_mesh_base():
-    """Guard cumesh/flex_gemm imports and unconditionally skip in-place mesh
-    ops. TRELLIS.2 calls fill_holes/remove_faces/simplify during decode on the
-    full 400K-vertex mesh; the Metal port of cumesh segfaults on inputs that
-    large, so we skip these decode-time ops entirely. Post-decode mesh
-    simplification happens later via fast_simplification before texture bake.
+    """Guard cumesh/flex_gemm imports, replace .cuda() with .to(self.device),
+    and gate cumesh-using mesh ops on `cumesh is not None`.
+
+    Historical note: this patcher used to unconditionally skip
+    fill_holes / remove_faces / simplify because Pedro Naugusto's Metal port
+    of cumesh used `atomic_min`/`atomic_max` on `float`, which is an
+    Apple9-only feature; on Apple7/8 (M1/M2) the kernel failed at
+    pipeline-creation time and crashed the whole pipeline.
+
+    With the Apple7/8 atomic-fallback patch in pedronaugusto/mtlmesh#1,
+    cumesh runs end-to-end on M1/M2, and skipping fill_holes measurably
+    hurts output quality (decoder mesh ships with ~4128 boundary loops
+    worth of small holes that the bake-time Metal stack only partially
+    closes — visible as see-through cylinders in the rendered GLB).
+
+    Soft-failure for users on unpatched mtlmesh is handled at the *caller*
+    site (`pipelines/trellis2_image_to_3d.py:474`) via a try/except, so
+    the body of each mesh method here stays straightforward.
     """
     path = os.path.join(TRELLIS_ROOT, "trellis2/representations/mesh/base.py")
     src = read_file(path)
@@ -260,39 +273,75 @@ def patch_mesh_base():
         '        raise RuntimeError("flex_gemm requires CUDA")',
     )
 
-    # Unconditionally return from fill_holes (Metal cumesh segfaults on large meshes)
+    # Replace `.cuda()` with `.to(self.device)` and add a `cumesh is None` early
+    # return so methods are no-ops on CPU-only builds rather than crashing.
     src = src.replace(
         "    def fill_holes(self, max_hole_perimeter=3e-2):\n"
         "        vertices = self.vertices.cuda()\n"
         "        faces = self.faces.cuda()",
         "    def fill_holes(self, max_hole_perimeter=3e-2):\n"
-        "        return  # Skip — Metal cumesh segfaults on large decode meshes\n"
+        "        if cumesh is None:\n"
+        "            return  # cumesh unavailable (CPU-only build)\n"
         "        vertices = self.vertices.to(self.device)\n"
         "        faces = self.faces.to(self.device)",
     )
-
-    # Unconditionally return from remove_faces
     src = src.replace(
         "    def remove_faces(self, face_mask: torch.Tensor):\n"
         "        vertices = self.vertices.cuda()\n"
         "        faces = self.faces.cuda()",
         "    def remove_faces(self, face_mask: torch.Tensor):\n"
-        "        return\n"
+        "        if cumesh is None:\n"
+        "            return  # cumesh unavailable (CPU-only build)\n"
         "        vertices = self.vertices.to(self.device)\n"
         "        faces = self.faces.to(self.device)",
     )
-
-    # Unconditionally return from simplify
     src = src.replace(
         "    def simplify(self, target=1000000, verbose: bool=False, options: dict={}):\n"
         "        vertices = self.vertices.cuda()\n"
         "        faces = self.faces.cuda()",
         "    def simplify(self, target=1000000, verbose: bool=False, options: dict={}):\n"
-        "        return\n"
+        "        if cumesh is None:\n"
+        "            return  # cumesh unavailable (CPU-only build)\n"
         "        vertices = self.vertices.to(self.device)\n"
         "        faces = self.faces.to(self.device)",
     )
 
+    write_file(path, src)
+
+
+def patch_pipeline_runtime_fallback():
+    """Wrap decode-time `m.fill_holes()` in a try/except so users on
+    unpatched mtlmesh (Apple7/8 without the atomic-fallback fix) degrade
+    gracefully instead of crashing the whole pipeline.
+    """
+    path = os.path.join(TRELLIS_ROOT, "trellis2/pipelines/trellis2_image_to_3d.py")
+    src = read_file(path)
+    if "fill_holes_warning_emitted" in src:
+        print(f"  Already patched: {os.path.relpath(path, TRELLIS_ROOT)}")
+        return
+
+    needle = "            m.fill_holes()"
+    replacement = (
+        "            try:\n"
+        "                m.fill_holes()\n"
+        "            except RuntimeError as e:\n"
+        "                # Apple7/8 (M1/M2) Metal cumesh without\n"
+        "                # pedronaugusto/mtlmesh#1 raises here. Degrade\n"
+        "                # gracefully (output mesh will have small holes).\n"
+        "                import warnings\n"
+        "                if not getattr(self, '_fill_holes_warning_emitted', False):\n"
+        "                    warnings.warn(\n"
+        '                        f"cumesh.fill_holes failed ({e}); skipping. "\n'
+        '                        \"On M1/M2 update mtlmesh to a build with \"\n'
+        '                        \"pedronaugusto/mtlmesh#1 (Apple7/8 atomic fallback).\",\n'
+        "                        stacklevel=2,\n"
+        "                    )\n"
+        "                    self._fill_holes_warning_emitted = True\n"
+    )
+    if needle not in src:
+        print(f"  Skipping (call site moved): {os.path.relpath(path, TRELLIS_ROOT)}")
+        return
+    src = src.replace(needle, replacement)
     write_file(path, src)
 
 
@@ -437,6 +486,7 @@ def main():
     patch_image_feature_extractor()
     patch_birefnet()
     patch_mesh_base()
+    patch_pipeline_runtime_fallback()
     patch_fdg_vae()
     patch_pipeline()
     patch_pipeline_base()


### PR DESCRIPTION
## Summary

Removes the unconditional skip of cumesh's decode-time `fill_holes` /
`remove_faces` / `simplify` on Apple Silicon. The skip was a workaround
for a real bug — Metal cumesh used `atomic_min` / `atomic_max` on `float`,
which is an Apple9-only feature that crashed on M1/M2 — but the
workaround has been measurably hurting output quality.

With pedronaugusto/mtlmesh#1 in place (Apple7/8 atomic-fallback for the
simplify and atlas kernels), cumesh runs end-to-end on every Apple
Silicon GPU family. There's no longer a reason to skip these ops.

## Why this matters

Skipping `fill_holes` specifically had a visible cost. On the reference
T.png input on an M1 Pro:

- Decoder mesh ships with **167,529 boundary edges / 4,128 hole loops**.
- The bake-time Metal stack (`o_voxel.postprocess.to_glb`) does its own
  hole-fill on the decimated 200K-face mesh, but it can only close holes
  that survived the decimation step — many of the original decoder holes
  are gone before that point.
- Final GLB renders with see-through cylinders, gear-edge fragmentation,
  and z-sorting artifacts in any glTF viewer (donmccurdy, three.js,
  Blender's importer).

After re-enabling decode-time `fill_holes`:

- Closes the 4128 hole loops in <1s on the full 1.44M-vertex mesh.
- Final GLB face count: **994,484** vs upstream CUDA's 997,498 (within 0.3%).
- Visual parity with `upstream_ref.glb` in donmccurdy's viewer.

## Changes

1. **`patches/mps_compat.py: patch_mesh_base()`**
   - No longer prepends `return  # Skip — Metal cumesh segfaults...` to
     the three methods. Instead:
     - Replaces `.cuda()` with `.to(self.device)` — fixes the *original*
       bare-`.cuda()` bug for MPS, which the skip masked.
     - Adds an `if cumesh is None: return` guard so CPU-only builds
       without the Metal stack continue to skip cleanly.
     - Leaves the actual cumesh body in place so it runs normally when
       cumesh is importable.

2. **`patches/mps_compat.py: patch_pipeline_runtime_fallback()` (new)**
   - Wraps the decode-time `m.fill_holes()` call site in
     `pipelines/trellis2_image_to_3d.py` in a `try/except RuntimeError`.
     Users on unpatched mtlmesh (Apple7/8 without the atomic-fallback
     fix) get a one-time `warnings.warn` and degrade gracefully —
     "ship mesh with small holes" rather than crash the whole pipeline.
   - This is the safety net for users who pip-install before the
     upstream mtlmesh PR lands.

3. Calls the new patcher in `main()`.

## Validation

Apple M1 Pro 16 GB (Apple7), patched mtlmesh installed:

- `cumesh.fill_holes` runs in <1s on the 1,438,207-vertex /
  2,988,108-face decoder mesh, closing 4128 boundary loops, adding
  ~26K faces.
- Final GLB: **994,484 faces**, extents `1.000 × 0.923 × 0.381` vs
  upstream CUDA's `1.000 × 0.918 × 0.386`. Visual parity confirmed
  in donmccurdy's viewer.

Apple M1 Pro 16 GB, unpatched mtlmesh (legacy install simulating a user
who hasn't updated):

- Pipeline completes successfully.
- One-time warning emitted:
  `UserWarning: cumesh.fill_holes failed (...); skipping. On M1/M2 update
   mtlmesh to a build with pedronaugusto/mtlmesh#1 (Apple7/8 atomic
   fallback).`
- Output GLB ships with the original small holes (matches pre-PR
  behavior).

## Dependency

- Hard requirement for the quality improvement: pedronaugusto/mtlmesh#1
- Soft requirement: this PR works regardless — the try/except just keeps
  the old behavior on unpatched mtlmesh.

## Related

- pedronaugusto/mtlmesh#1 (Apple7/8 atomic-fallback)
- pedronaugusto/trellis2-apple#1 (`alphaMode='OPAQUE'` default — separate
  bug fix needed for end-to-end correctness on Apple Silicon)
- shivampkumar/trellis-mac#5 (FotisK's original investigation that
  surfaced both fixes)