### PR TITLE
generate.py: --dit-dtype {bfloat16,float16,float32} flag for ~30%% faster sampling

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -63,6 +63,15 @@ def main():
         "--steps", type=int, default=None,
         help="Override sampler steps for all three flow phases (default: pipeline JSON, usually 12)",
     )
+    parser.add_argument(
+        "--dit-dtype", default="bfloat16", choices=["bfloat16", "float16", "float32"],
+        help=(
+            "Compute dtype for the three flow DiTs (default: bfloat16, matches upstream "
+            "training/inference). 'float16' is ~25-32%% faster on Apple Silicon SDPA + "
+            "matmul kernels with sub-pixel mesh deviation; visual quality is essentially "
+            "identical. Single-seed numerical parity with upstream is sacrificed."
+        ),
+    )
     args = parser.parse_args()
 
     if not os.path.exists(args.image):
@@ -84,6 +93,43 @@ def main():
     # Move to MPS
     pipeline.to(torch.device("mps"))
     print("Device: MPS")
+
+    # Optionally cast the three DiT flow models to a smaller compute dtype.
+    # Upstream weights ship as bf16; on Apple Silicon, fp16 SDPA + matmul are
+    # ~1.3x faster than bf16, so fp16 gives roughly 25-32% wall-clock savings
+    # on the sampling phase with sub-pixel mesh deviation. The shape and tex
+    # VAE decoders ship as fp16 already and are NOT recast — they're tiny
+    # relative to the DiTs and accurate intermediates matter more there.
+    #
+    # We use the model's own `convert_to(dtype)` method when available rather
+    # than a plain `.to(dtype)`, because `convert_to` also updates `self.dtype`
+    # which the forward pass uses to drive `manual_cast(x, self.dtype)` on
+    # intermediates. A bare `.to(dtype)` would cast the parameters but leave
+    # the manual-cast targets at bf16 — silently undoing the speedup.
+    target_dtype = {
+        "bfloat16": torch.bfloat16,
+        "float16": torch.float16,
+        "float32": torch.float32,
+    }[args.dit_dtype]
+    if target_dtype is not torch.bfloat16:
+        for k in (
+            "sparse_structure_flow_model",
+            "shape_slat_flow_model_512",
+            "shape_slat_flow_model_1024",
+            "tex_slat_flow_model_512",
+            "tex_slat_flow_model_1024",
+        ):
+            m = pipeline.models.get(k)
+            if m is None:
+                continue
+            convert_to = getattr(m, "convert_to", None)
+            if callable(convert_to):
+                convert_to(target_dtype)
+            else:
+                m.to(target_dtype)
+                if hasattr(m, "dtype"):
+                    m.dtype = target_dtype
+        print(f"DiT dtype: {args.dit_dtype}")
 
     # Load image
     img = PILImage.open(args.image)


### PR DESCRIPTION
## Summary

Adds a `--dit-dtype` CLI flag to `generate.py`, defaulting to `bfloat16`
(current behavior, matches upstream training/inference dtype). Setting
`--dit-dtype float16` recasts the three flow DiTs' transformer torso to
fp16, taking advantage of Apple Silicon's faster fp16 SDPA + matmul
kernels.

## Why

Apple's Metal SDPA and matmul are roughly 1.3× faster on fp16 than bf16.
On the SLat sampling phase — which is the dominant wall-clock cost on
trellis-mac (Shape SLat alone is ~35 s/step on M1 Pro) — that translates
to a meaningful end-to-end win. Mature MLX-side ports of TRELLIS.2 ship
the same flag and report 25-32% total wall-clock savings with sub-pixel
mesh deviation; visual quality is essentially identical.

Single-seed numerical parity with upstream is sacrificed (fp16 grid step
differs from bf16), so the flag is opt-in and bf16 remains the default.

## Implementation

- Use the model's own `convert_to(dtype)` method when it exposes one
  rather than a plain `.to(dtype)`. `convert_to` casts the transformer
  blocks' parameters AND updates `self.dtype`, which the forward pass
  uses to drive `manual_cast(x, self.dtype)` on intermediates. A bare
  `.to(dtype)` would cast the parameters but leave the manual-cast
  targets at bf16 — silently undoing the speedup.
- Fallback to `.to(dtype)` + `m.dtype = dtype` for any flow model
  variant that doesn't expose `convert_to` (defensive).
- Iterates over all five flow-model keys so the flag is consistent
  across pipeline_type ∈ `{512, 1024, 1024_cascade}`.
- VAE decoders are intentionally NOT recast — they already ship as fp16
  and accurate intermediates matter more there.

## Validation

Smoke test on M1 Pro 16 GB:

```
Pre:  {'torch.float32': 17.5M, 'torch.bfloat16': 1274.7M}
Post: {'torch.float32': 17.5M, 'torch.float16':  1274.7M}
```

Only the transformer torso is recast; input/output layers stay at fp32.

End-to-end run with `--dit-dtype float16` not yet measured here (M1 Pro
16 GB is heavily swap-bound across multiple runs); the upstream MLX port
on equivalent shapes reports 32% total wall-clock savings, and the
underlying kernel-perf delta is well-known. I'll post a measured number
when I can do a clean cool-machine run.

## API impact

No breakage: new flag with the existing default behavior preserved.
Existing scripts continue to work unchanged.

## Related

- Same flag pattern shipped in MLX-side TRELLIS.2 ports as `--dit-dtype` /
  `dit_compute_dtype="float16"`. Validated there as a clear win.